### PR TITLE
fix audit4j-demo-spring-retclinic to use version 2.4.1 of audit4j

### DIFF
--- a/audit4j-demo-spring-petclinic/pom.xml
+++ b/audit4j-demo-spring-petclinic/pom.xml
@@ -21,7 +21,7 @@
 		<spring-data-jpa.version>1.7.1.RELEASE</spring-data-jpa.version>
 
 		<!-- Audit4j -->
-		<audit4j.version>2.3.1</audit4j.version>
+		<audit4j.version>2.4.1</audit4j.version>
 
 		<!-- Java EE / Java SE dependencies -->
 		<jsp.version>2.2</jsp.version>
@@ -77,6 +77,12 @@
 			<groupId>org.audit4j</groupId>
 			<artifactId>audit4j-core</artifactId>
 			<version>${audit4j.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>javax.servlet</groupId>
+					<artifactId>servlet-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.audit4j</groupId>
@@ -453,7 +459,7 @@
 			<plugin>
 				<groupId>org.apache.tomcat.maven</groupId>
 				<artifactId>tomcat7-maven-plugin</artifactId>
-				<version>2.0</version>
+				<version>2.2</version>
 				<configuration>
 					<server>tomcat-development-server</server>
 					<port>9966</port>

--- a/audit4j-demo-spring-petclinic/src/main/java/org/springframework/samples/petclinic/util/AuditMetaData.java
+++ b/audit4j-demo-spring-petclinic/src/main/java/org/springframework/samples/petclinic/util/AuditMetaData.java
@@ -11,4 +11,9 @@ public class AuditMetaData implements MetaData{
         return "annonymous";
     }
 
+	@Override
+	public String getOrigin() {
+		return "origin";
+	}
+
 }

--- a/audit4j-demo-spring-petclinic/src/main/java/org/springframework/samples/petclinic/util/CallMonitoringAspect.java
+++ b/audit4j-demo-spring-petclinic/src/main/java/org/springframework/samples/petclinic/util/CallMonitoringAspect.java
@@ -75,7 +75,6 @@ public class CallMonitoringAspect {
 
     @Around("within(@org.springframework.stereotype.Repository *)")
     public Object invoke(ProceedingJoinPoint joinPoint) throws Throwable {
-        System.out.println("dfddf");
         if (this.enabled) {
             StopWatch sw = new StopWatch(joinPoint.toShortString());
 


### PR DESCRIPTION
This is a first fix using audit4j 2.4.1
When the version 2.5.0 of Audit4j-spring is reading
I will create a new fix to use the version 2.5.0